### PR TITLE
Update radiation_io.py for logarithmic data

### DIFF
--- a/src/fastran/radiation/impurity_radiation.py
+++ b/src/fastran/radiation/impurity_radiation.py
@@ -76,11 +76,12 @@ class impurity_radiation(Component):
         a_imp = instate['a_imp']
         z_imp = instate['z_imp']
         rho = instate['rho']
+        p_rad = np.zeros(len(rho))
         for k, z in enumerate(z_imp):
             ne = instate[f'ne'] * 1.e19
             nz = instate[f'density_imp_{k}'] * 1.e19
             te = instate['te'] * 1.e3
-            p_rad = self.Lz[z](te, ne) * ne * nz
+            p_rad += self.Lz[z](te, ne) * ne * nz
             print(k, p_rad)
         instate['p_rad'] = -p_rad * 1.e-6
         instate.write(cur_instate_file)

--- a/src/fastran/radiation/radiation_io.py
+++ b/src/fastran/radiation/radiation_io.py
@@ -16,7 +16,7 @@ class radiation_io():
      
     tiny = np.finfo(np.float64).tiny
 
-    def log10_with_floor(self, x: xr.DataArray | np.ndarray | float) -> xr.DataArray | np.ndarray | float:
+    def log10_with_floor(self, x: np.ndarray | float) -> np.ndarray | float:
         """Return the log of x if x > 0, and otherwise return the log of the smallest representable float."""
         return np.log10(np.maximum(x, self.tiny))
     
@@ -32,8 +32,8 @@ class radiation_io():
         print(dim_ne[0], dim_ne[-1])
         print(dim_te[0], dim_te[-1])
         """Data is log scale so must take log off all quantities before interpolation"""
-        self.Lz = RectBivariateSpline(log10_with_floor(dim_te), log10_with_floor(dim_ne), log10_with_floor(data_Lz)) 
+        self.Lz = RectBivariateSpline(self.log10_with_floor(dim_te), self.log10_with_floor(dim_ne), self.log10_with_floor(data_Lz)) 
        
     def __call__(self, te, ne, nte_tau=0.5e17):
         '''Return 10 to the power of result'''
-        return np.power(10, self.Lz(log10_with_floor(te), log10_with_floor(ne), grid=False)) #must be temp in eV, density in m^-3
+        return np.power(10, self.Lz(self.log10_with_floor(te), self.log10_with_floor(ne), grid=False)) #must be temp in eV, density in m^-3

--- a/src/fastran/radiation/radiation_io.py
+++ b/src/fastran/radiation/radiation_io.py
@@ -5,7 +5,7 @@
 """
 import os
 import numpy as np
-from scipy.interpolate import RegularGridInterpolator
+from scipy.interpolate import RectBivariateSpline
 import netCDF4
 
 
@@ -13,19 +13,27 @@ class radiation_io():
     def __init__(self, dir_data='.'):
         self.dir_data = dir_data
         pass
+     
+    tiny = np.finfo(np.float64).tiny
+
+    def log10_with_floor(self, x: xr.DataArray | np.ndarray | float) -> xr.DataArray | np.ndarray | float:
+        """Return the log of x if x > 0, and otherwise return the log of the smallest representable float."""
+        return np.log10(np.maximum(x, self.tiny))
     
     def read(self, impurity_name):
         #-- read genray output
         ncfile = os.path.join(self.dir_data, f'{impurity_name}.nc')
         data = netCDF4.Dataset(ncfile, 'r', format='NETCDF4')
-        data_Lz = data.variables['equilibrium_Lz'][:, :, :]
+        data_Lz = data.variables['coronal_Lz'][:, :]
         dim_ne_tau = data.variables['dim_ne_tau'][:]
         dim_ne = data.variables['dim_electron_density'][:]
         dim_te = data.variables['dim_electron_temp'][:]
         print(dim_ne_tau)
         print(dim_ne[0], dim_ne[-1])
         print(dim_te[0], dim_te[-1])
-        self.Lz = RegularGridInterpolator((dim_te, dim_ne, dim_ne_tau), data_Lz) 
-    
+        """Data is log scale so must take log off all quantities before interpolation"""
+        self.Lz = RectBivariateSpline(log10_with_floor(dim_te), log10_with_floor(dim_ne), log10_with_floor(data_Lz)) 
+       
     def __call__(self, te, ne, nte_tau=0.5e17):
-        return self.Lz((te, ne, nte_tau))
+        '''Return 10 to the power of result'''
+        return np.power(10, self.Lz(log10_with_floor(te), log10_with_floor(ne), grid=False)) #must be temp in eV, density in m^-3

--- a/src/fastran/radiation/radiation_io.py
+++ b/src/fastran/radiation/radiation_io.py
@@ -16,7 +16,7 @@ class radiation_io():
      
     tiny = np.finfo(np.float64).tiny
 
-    def log10_with_floor(self, x: np.ndarray | float) -> np.ndarray | float:
+    def log10_with_floor(self, x):
         """Return the log of x if x > 0, and otherwise return the log of the smallest representable float."""
         return np.log10(np.maximum(x, self.tiny))
     


### PR DESCRIPTION
Changes made following the radiation model implemented in cfspopcon: Changed Lz data pulled to coronal instead of equilbrium. Because the atomic data is log-scale, interpolator changed to be over a log-log grid and result changed to 10 to the power of result.